### PR TITLE
Add cluster max harvest tag to paxels

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/cluster_max_harvestables.json
+++ b/src/main/resources/data/minecraft/tags/items/cluster_max_harvestables.json
@@ -1,0 +1,11 @@
+{
+	"replace": false,
+	"values": [
+    "azure-paxels:wooden_paxel",
+    "azure-paxels:stone_paxel",
+    "azure-paxels:iron_paxel",
+    "azure-paxels:golden_paxel",
+    "azure-paxels:diamond_paxel",
+    "azure-paxels:netherite_paxel"
+	]
+}

--- a/src/main/resources/data/minecraft/tags/items/cluster_max_harvestables.json
+++ b/src/main/resources/data/minecraft/tags/items/cluster_max_harvestables.json
@@ -1,11 +1,11 @@
 {
 	"replace": false,
 	"values": [
-    "azure-paxels:wooden_paxel",
-    "azure-paxels:stone_paxel",
-    "azure-paxels:iron_paxel",
-    "azure-paxels:golden_paxel",
-    "azure-paxels:diamond_paxel",
-    "azure-paxels:netherite_paxel"
+		"azure-paxels:wooden_paxel",
+		"azure-paxels:stone_paxel",
+		"azure-paxels:iron_paxel",
+		"azure-paxels:golden_paxel",
+		"azure-paxels:diamond_paxel",
+		"azure-paxels:netherite_paxel"
 	]
 }


### PR DESCRIPTION
Resolves #3 

Adds the minecraft:cluster_max_harvestables tag to the paxels, allowing increased drops and fortune to apply as with other pickaxes.